### PR TITLE
fix: correct Audioflare project URL

### DIFF
--- a/src/lib/constants.tsx
+++ b/src/lib/constants.tsx
@@ -82,7 +82,7 @@ export const PROJECTS: Project[] = [
   },
   {
     name: 'Audioflare',
-    url: 'https://audioflare.seanoliver/dev/',
+    url: 'https://audioflare.seanoliver.dev/',
     github: 'https://github.com/seanoliver/audioflare',
     description:
       'An all-in-one AI audio playground using Cloudflare AI Workers to transcribe, analyze, summarize, and translate any audio file.',


### PR DESCRIPTION
Fixes #18

Update the Audioflare project card to use the correct `audioflare.seanoliver.dev` URL.

Verification:
- `git diff --check`
- Confirmed the old mistyped URL is no longer present in `src/lib/constants.tsx`