### PR TITLE
fix(goodreads): parse plain-text RSS fields dropped by CDATA-only regexes

### DIFF
--- a/docs/bugs/2026-07-11-goodreads-cdata-only-parser-drops-books.md
+++ b/docs/bugs/2026-07-11-goodreads-cdata-only-parser-drops-books.md
@@ -1,0 +1,70 @@
+# Goodreads shelf parser drops every book whose RSS title isn't CDATA-wrapped
+
+**Date:** 2026-07-11 **Branch:** main **Caught by:** user report — homepage
+"Read" section showed the wrong books with no ratings or dates
+
+## Symptom
+
+The homepage Read section (top 3 books) showed one correct recent book
+(Hard-Boiled Wonderland, ★★★★, 06 05 2026) followed by books with no rating and
+no completion date (Harry Potter and the Cursed Child, The Paper Menagerie).
+Recent reads like Flowers for Algernon (finished 06/13/2026, rated 5) were
+missing entirely, even though it was the _most recent_ book on the shelf.
+
+## Root cause
+
+Goodreads' RSS feed (`/review/list_rss/<user>?shelf=read`) mixes two encodings
+in the same feed: titles needing XML escaping arrive as
+`<title><![CDATA[...]]></title>`, plain ones as
+`<title>Flowers for Algernon</title>`. At time of fix, 39 of 100 items in the
+feed used the plain form.
+
+The parser in `src/app/api/goodreads/route.ts` matched titles only with
+`/<title><!\[CDATA\[(.*?)\]\]><\/title>/` and returned `null` when it didn't
+match, silently dropping every plain-title book — including most recent, dated,
+rated reads.
+
+A second defect made the survivors look worse: the sort comparator returned `0`
+whenever either book lacked a `dateRead`. An inconsistent comparator leaves
+undated books (a 2026-03-02 bulk import with no read dates or ratings — the
+Harry Potter / Paper Menagerie items, which _are_ on the read shelf) floating
+near the top in feed order instead of sinking below dated books.
+
+## Repro steps
+
+1. On main at 9ea3eaa, run
+   `curl -A 'Mozilla/5.0' 'https://www.goodreads.com/review/list_rss/<GOODREADS_USER_ID>?shelf=read'`
+   and observe both `<title><![CDATA[...]]></title>` and plain
+   `<title>...</title>` items.
+2. `pnpm dev`, then `curl http://localhost:3000/api/goodreads`.
+3. Observe plain-title books (e.g. Flowers for Algernon) absent from `books`,
+   and undated/unrated books near the top of the list.
+
+## Fix
+
+Extracted parsing into `src/lib/goodreads.ts` (`parseReadShelf`,
+`parseCurrentlyReadingShelf`) with an `extractTag` helper whose regex accepts
+both CDATA and plain-text tag content (decoding XML entities for the plain
+form), and a consistent sort comparator that treats a missing `dateRead` as
+epoch 0 so undated books sort last. The route now just fetches and delegates.
+Extraction (vs. patching regexes in the route) makes the parser unit-testable
+without mocking `fetch`.
+
+## Verification
+
+- `pnpm test:unit` — 80 passed, including 8 new tests in
+  `src/lib/goodreads.test.ts` covering plain titles, CDATA titles, mixed feeds,
+  entity decoding, empty `user_read_at`, and sort order.
+- `pnpm typecheck` clean (after clearing stale `.next` type stubs left from the
+  posts→writing rename).
+- Live check: `pnpm dev` + `curl /api/goodreads` returned 30 books, ordered
+  Flowers for Algernon (5★, 06/13) → Hard-Boiled Wonderland (4★, 06/05) → The
+  Ministry for the Future (2★, 05/08), with undated bulk-import books below all
+  dated ones.
+
+## Recurrence guardrail
+
+`src/lib/goodreads.test.ts` fixtures include a plain-text-title item and a
+mixed-encoding feed; if a future edit reintroduces a CDATA-only regex, those
+tests fail. A comment on `extractTag` documents that Goodreads mixes both
+encodings in a single feed.

--- a/docs/bugs/2026-07-11-goodreads-cdata-only-parser-drops-books.md
+++ b/docs/bugs/2026-07-11-goodreads-cdata-only-parser-drops-books.md
@@ -45,22 +45,33 @@ near the top in feed order instead of sinking below dated books.
 Extracted parsing into `src/lib/goodreads.ts` (`parseReadShelf`,
 `parseCurrentlyReadingShelf`) with an `extractTag` helper whose regex accepts
 both CDATA and plain-text tag content (decoding XML entities for the plain
-form), and a consistent sort comparator that treats a missing `dateRead` as
-epoch 0 so undated books sort last. The route now just fetches and delegates.
-Extraction (vs. patching regexes in the route) makes the parser unit-testable
-without mocking `fetch`.
+form). The route now just fetches and delegates. Extraction (vs. patching
+regexes in the route) makes the parser unit-testable without mocking `fetch`.
+
+Two follow-on decisions after Sean reviewed:
+
+- Shelf entries without a `user_read_at` are excluded from display entirely
+  (rather than sorted last) — the 2026-03-02 bulk import put ~96 undated,
+  unrated entries on the read shelf that he doesn't consider read, and the
+  parser can't otherwise distinguish them from finished books. Tradeoff: a
+  future finished book with no read date set won't appear.
+- The route fetches read-shelf RSS pages 1 and 2 (Goodreads caps each page at
+  100 items, sorted by date added). The bulk import fills nearly all of page 1,
+  so only 4 dated reads were visible there; the rest of the real reading history
+  lives on page 2. Books are merged across pages, sorted by read date, and
+  capped at 30 after filtering.
 
 ## Verification
 
-- `pnpm test:unit` — 80 passed, including 8 new tests in
+- `pnpm test:unit` — 81 passed, including 9 new tests in
   `src/lib/goodreads.test.ts` covering plain titles, CDATA titles, mixed feeds,
-  entity decoding, empty `user_read_at`, and sort order.
+  entity decoding, undated-entry exclusion, multi-page merge, and sort order.
 - `pnpm typecheck` clean (after clearing stale `.next` type stubs left from the
   posts→writing rename).
-- Live check: `pnpm dev` + `curl /api/goodreads` returned 30 books, ordered
-  Flowers for Algernon (5★, 06/13) → Hard-Boiled Wonderland (4★, 06/05) → The
-  Ministry for the Future (2★, 05/08), with undated bulk-import books below all
-  dated ones.
+- Live check: `pnpm dev` + `curl /api/goodreads` returned 30 dated, rated books
+  ordered Flowers for Algernon (5★, 06/13) → Hard-Boiled Wonderland (4★, 06/05)
+  → The Ministry for the Future (2★, 05/08) → …, with no undated bulk-import
+  entries in the list.
 
 ## Recurrence guardrail
 

--- a/src/app/api/goodreads/route.ts
+++ b/src/app/api/goodreads/route.ts
@@ -17,21 +17,30 @@ export async function GET(): Promise<Response> {
       )
     }
 
-    // Fetch both read and currently-reading shelves
-    const [readResponse, currentlyReadingResponse] = await Promise.all([
-      fetch(`https://www.goodreads.com/review/list_rss/${userId}?shelf=read`, {
-        headers: { 'User-Agent': 'Mozilla/5.0' },
-      }),
-      fetch(
-        `https://www.goodreads.com/review/list_rss/${userId}?shelf=currently-reading`,
-        {
-          headers: { 'User-Agent': 'Mozilla/5.0' },
-        }
-      ),
-    ])
+    // Fetch the read shelf and the currently-reading shelf. The read
+    // shelf spans two RSS pages (100 items each) because a 2026-03-02
+    // bulk import of undated entries fills most of page 1 — dated reads
+    // live mostly on page 2.
+    const [readPage1Response, readPage2Response, currentlyReadingResponse] =
+      await Promise.all([
+        fetch(
+          `https://www.goodreads.com/review/list_rss/${userId}?shelf=read&page=1`,
+          { headers: { 'User-Agent': 'Mozilla/5.0' } }
+        ),
+        fetch(
+          `https://www.goodreads.com/review/list_rss/${userId}?shelf=read&page=2`,
+          { headers: { 'User-Agent': 'Mozilla/5.0' } }
+        ),
+        fetch(
+          `https://www.goodreads.com/review/list_rss/${userId}?shelf=currently-reading`,
+          { headers: { 'User-Agent': 'Mozilla/5.0' } }
+        ),
+      ])
 
-    if (!readResponse.ok) {
-      throw new Error(`Goodreads read shelf returned ${readResponse.status}`)
+    for (const response of [readPage1Response, readPage2Response]) {
+      if (!response.ok) {
+        throw new Error(`Goodreads read shelf returned ${response.status}`)
+      }
     }
 
     if (!currentlyReadingResponse.ok) {
@@ -40,10 +49,15 @@ export async function GET(): Promise<Response> {
       )
     }
 
-    const readXml = await readResponse.text()
-    const currentlyReadingXml = await currentlyReadingResponse.text()
+    const [readPage1Xml, readPage2Xml, currentlyReadingXml] = await Promise.all(
+      [
+        readPage1Response.text(),
+        readPage2Response.text(),
+        currentlyReadingResponse.text(),
+      ]
+    )
 
-    const books = parseReadShelf(readXml)
+    const books = parseReadShelf(readPage1Xml, readPage2Xml)
     const currentlyReading = parseCurrentlyReadingShelf(currentlyReadingXml)
 
     return NextResponse.json({ books, currentlyReading })

--- a/src/app/api/goodreads/route.ts
+++ b/src/app/api/goodreads/route.ts
@@ -1,23 +1,10 @@
 import { NextResponse } from 'next/server'
 
+import { parseCurrentlyReadingShelf, parseReadShelf } from '@/lib/goodreads'
+
 // Use Node.js runtime for better XML parsing performance
 export const runtime = 'nodejs'
 export const revalidate = 3600
-
-interface Book {
-  title: string
-  author: string
-  dateRead: string
-  link: string
-  rating: number
-}
-
-interface CurrentlyReadingBook {
-  title: string
-  author: string
-  dateStarted: string
-  link: string
-}
 
 export async function GET(): Promise<Response> {
   try {
@@ -56,82 +43,8 @@ export async function GET(): Promise<Response> {
     const readXml = await readResponse.text()
     const currentlyReadingXml = await currentlyReadingResponse.text()
 
-    // Helper function to clean title
-    const cleanTitle = (title: string): string => {
-      let cleaned = title.split(':')[0]
-      cleaned = cleaned.replace(/\s*\([^)]*\)\s*$/, '')
-      return cleaned.trim()
-    }
-
-    // Helper function to parse read book from XML item
-    const parseBook = (item: string): Book | null => {
-      const titleMatch = item.match(/<title><!\[CDATA\[(.*?)\]\]><\/title>/)
-      const linkMatch = item.match(/<link><!\[CDATA\[(.*?)\]\]><\/link>/)
-      const dateReadMatch = item.match(
-        /<user_read_at><!\[CDATA\[(.*?)\]\]><\/user_read_at>/
-      )
-      const authorMatch = item.match(/<author_name>(.*?)<\/author_name>/)
-      const ratingMatch = item.match(/<user_rating>(.*?)<\/user_rating>/)
-
-      if (!titleMatch || !authorMatch) return null
-
-      return {
-        title: cleanTitle(titleMatch[1]),
-        author: authorMatch[1].trim(),
-        dateRead: dateReadMatch ? dateReadMatch[1] : '',
-        link: linkMatch ? linkMatch[1] : '',
-        rating: ratingMatch ? parseInt(ratingMatch[1], 10) : 0,
-      }
-    }
-
-    // Helper function to parse currently reading book from XML item
-    const parseCurrentlyReadingBook = (
-      item: string
-    ): CurrentlyReadingBook | null => {
-      const titleMatch = item.match(/<title><!\[CDATA\[(.*?)\]\]><\/title>/)
-      const linkMatch = item.match(/<link><!\[CDATA\[(.*?)\]\]><\/link>/)
-      const dateStartedMatch = item.match(
-        /<user_date_added><!\[CDATA\[(.*?)\]\]><\/user_date_added>/
-      )
-      const authorMatch = item.match(/<author_name>(.*?)<\/author_name>/)
-
-      if (!titleMatch || !authorMatch) return null
-
-      return {
-        title: cleanTitle(titleMatch[1]),
-        author: authorMatch[1].trim(),
-        dateStarted: dateStartedMatch ? dateStartedMatch[1] : '',
-        link: linkMatch ? linkMatch[1] : '',
-      }
-    }
-
-    // Parse currently reading book
-    const itemRegex = /<item>[\s\S]*?<\/item>/g
-    const currentlyReadingItems = currentlyReadingXml.match(itemRegex) || []
-    // Destructure instead of indexing: `match() || []` is typed
-    // `RegExpMatchArray | []`, so [0] is `string | undefined` and matched
-    // items are always non-empty strings, making truthiness equivalent to
-    // the old `.length > 0` check.
-    const [firstCurrentlyReadingItem] = currentlyReadingItems
-    const currentlyReading = firstCurrentlyReadingItem
-      ? parseCurrentlyReadingBook(firstCurrentlyReadingItem)
-      : null
-
-    // Parse read books
-    const books: Book[] = []
-    const readItems = readXml.match(itemRegex) || []
-
-    for (let i = 0; i < Math.min(readItems.length, 30); i++) {
-      const book = parseBook(readItems[i])
-      if (book) {
-        books.push(book)
-      }
-    }
-
-    books.sort((a, b) => {
-      if (!a.dateRead || !b.dateRead) return 0
-      return new Date(b.dateRead).getTime() - new Date(a.dateRead).getTime()
-    })
+    const books = parseReadShelf(readXml)
+    const currentlyReading = parseCurrentlyReadingShelf(currentlyReadingXml)
 
     return NextResponse.json({ books, currentlyReading })
   } catch (error) {

--- a/src/lib/goodreads.test.ts
+++ b/src/lib/goodreads.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseCurrentlyReadingShelf, parseReadShelf } from './goodreads'
+
+/**
+ * Goodreads RSS mixes two encodings within the same feed: fields whose
+ * content needs escaping arrive CDATA-wrapped, plain ones don't. A parser
+ * that only accepts one form silently drops the other (~40% of a real
+ * feed at time of writing).
+ */
+
+const readItem = (opts: {
+  title: string
+  cdataTitle?: boolean
+  author?: string
+  readAt?: string
+  rating?: number
+  link?: string
+}): string => {
+  const {
+    title,
+    cdataTitle = false,
+    author = 'Some Author',
+    readAt = '',
+    rating = 0,
+    link = 'https://www.goodreads.com/review/show/1',
+  } = opts
+  const titleXml = cdataTitle ? `<![CDATA[${title}]]>` : title
+  const readAtXml = readAt ? `<![CDATA[${readAt}]]>` : ''
+  return `<item>
+    <title>${titleXml}</title>
+    <link><![CDATA[${link}]]></link>
+    <author_name>${author}</author_name>
+    <user_rating>${rating}</user_rating>
+    <user_read_at>${readAtXml}</user_read_at>
+    <user_date_added><![CDATA[Mon, 02 Mar 2026 05:35:25 -0800]]></user_date_added>
+  </item>`
+}
+
+describe('parseReadShelf', () => {
+  it('parses items whose title is plain text (no CDATA)', () => {
+    const books = parseReadShelf(
+      readItem({
+        title: 'Flowers for Algernon',
+        readAt: 'Sat, 13 Jun 2026 00:00:00 +0000',
+        rating: 5,
+      })
+    )
+    expect(books).toHaveLength(1)
+    expect(books[0].title).toBe('Flowers for Algernon')
+    expect(books[0].rating).toBe(5)
+    expect(books[0].dateRead).toBe('Sat, 13 Jun 2026 00:00:00 +0000')
+  })
+
+  it('parses items whose title is CDATA-wrapped', () => {
+    const books = parseReadShelf(
+      readItem({
+        title: 'Harry Potter and the Cursed Child, Parts 1 & 2',
+        cdataTitle: true,
+      })
+    )
+    expect(books).toHaveLength(1)
+    expect(books[0].title).toBe(
+      'Harry Potter and the Cursed Child, Parts 1 & 2'
+    )
+  })
+
+  it('decodes XML entities in plain-text fields', () => {
+    const books = parseReadShelf(readItem({ title: 'War &amp; Peace' }))
+    expect(books[0].title).toBe('War & Peace')
+  })
+
+  it('keeps both encodings from a single mixed feed', () => {
+    const xml =
+      readItem({ title: 'Plain Title Book' }) +
+      readItem({ title: 'CDATA Title Book', cdataTitle: true })
+    expect(parseReadShelf(xml).map((b) => b.title)).toEqual(
+      expect.arrayContaining(['Plain Title Book', 'CDATA Title Book'])
+    )
+  })
+
+  it('sorts newest read date first and sinks undated books to the bottom', () => {
+    const xml =
+      readItem({ title: 'Undated Book' }) +
+      readItem({
+        title: 'Older Book',
+        readAt: 'Fri, 5 Jun 2026 00:00:00 +0000',
+      }) +
+      readItem({
+        title: 'Newest Book',
+        readAt: 'Sat, 13 Jun 2026 00:00:00 +0000',
+      })
+    expect(parseReadShelf(xml).map((b) => b.title)).toEqual([
+      'Newest Book',
+      'Older Book',
+      'Undated Book',
+    ])
+  })
+
+  it('treats an empty user_read_at as no date instead of dropping the book', () => {
+    const books = parseReadShelf(readItem({ title: 'No Date Book' }))
+    expect(books).toHaveLength(1)
+    expect(books[0].dateRead).toBe('')
+    expect(books[0].rating).toBe(0)
+  })
+})
+
+describe('parseCurrentlyReadingShelf', () => {
+  it('parses a plain-text title', () => {
+    const book = parseCurrentlyReadingShelf(
+      readItem({ title: 'The Ministry for the Future' })
+    )
+    expect(book?.title).toBe('The Ministry for the Future')
+    expect(book?.dateStarted).toBe('Mon, 02 Mar 2026 05:35:25 -0800')
+  })
+
+  it('returns null for an empty feed', () => {
+    expect(parseCurrentlyReadingShelf('<rss></rss>')).toBeNull()
+  })
+})

--- a/src/lib/goodreads.test.ts
+++ b/src/lib/goodreads.test.ts
@@ -21,7 +21,7 @@ const readItem = (opts: {
     title,
     cdataTitle = false,
     author = 'Some Author',
-    readAt = '',
+    readAt = 'Mon, 02 Mar 2026 00:00:00 +0000',
     rating = 0,
     link = 'https://www.goodreads.com/review/show/1',
   } = opts
@@ -79,9 +79,8 @@ describe('parseReadShelf', () => {
     )
   })
 
-  it('sorts newest read date first and sinks undated books to the bottom', () => {
+  it('sorts by read date, newest first', () => {
     const xml =
-      readItem({ title: 'Undated Book' }) +
       readItem({
         title: 'Older Book',
         readAt: 'Fri, 5 Jun 2026 00:00:00 +0000',
@@ -93,15 +92,32 @@ describe('parseReadShelf', () => {
     expect(parseReadShelf(xml).map((b) => b.title)).toEqual([
       'Newest Book',
       'Older Book',
-      'Undated Book',
     ])
   })
 
-  it('treats an empty user_read_at as no date instead of dropping the book', () => {
-    const books = parseReadShelf(readItem({ title: 'No Date Book' }))
-    expect(books).toHaveLength(1)
-    expect(books[0].dateRead).toBe('')
-    expect(books[0].rating).toBe(0)
+  it('merges multiple RSS pages and sorts across them', () => {
+    const page1 = readItem({
+      title: 'Page One Book',
+      readAt: 'Fri, 5 Jun 2026 00:00:00 +0000',
+    })
+    const page2 = readItem({
+      title: 'Page Two Newer Book',
+      readAt: 'Sat, 13 Jun 2026 00:00:00 +0000',
+    })
+    expect(parseReadShelf(page1, page2).map((b) => b.title)).toEqual([
+      'Page Two Newer Book',
+      'Page One Book',
+    ])
+  })
+
+  it('excludes shelf entries without a read date (bulk-import noise)', () => {
+    const xml =
+      readItem({ title: 'Undated Import', readAt: '' }) +
+      readItem({
+        title: 'Real Read',
+        readAt: 'Sat, 13 Jun 2026 00:00:00 +0000',
+      })
+    expect(parseReadShelf(xml).map((b) => b.title)).toEqual(['Real Read'])
   })
 })
 

--- a/src/lib/goodreads.ts
+++ b/src/lib/goodreads.ts
@@ -1,0 +1,98 @@
+export interface Book {
+  title: string
+  author: string
+  dateRead: string
+  link: string
+  rating: number
+}
+
+export interface CurrentlyReadingBook {
+  title: string
+  author: string
+  dateStarted: string
+  link: string
+}
+
+/**
+ * Goodreads RSS is inconsistent about CDATA: fields with characters that
+ * need escaping arrive as `<title><![CDATA[...]]></title>`, plain ones as
+ * `<title>...</title>`. Both forms must parse or ~40% of shelf items get
+ * silently dropped.
+ */
+const extractTag = (item: string, tag: string): string => {
+  const match = item.match(
+    new RegExp(
+      `<${tag}>(?:<!\\[CDATA\\[([\\s\\S]*?)\\]\\]>|([\\s\\S]*?))</${tag}>`
+    )
+  )
+  if (!match) return ''
+  if (match[1] !== undefined) return match[1]
+  return decodeEntities(match[2] ?? '')
+}
+
+const decodeEntities = (text: string): string =>
+  text
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&')
+
+const cleanTitle = (title: string): string => {
+  let cleaned = title.split(':')[0]
+  cleaned = cleaned.replace(/\s*\([^)]*\)\s*$/, '')
+  return cleaned.trim()
+}
+
+const ITEM_REGEX = /<item>[\s\S]*?<\/item>/g
+const MAX_READ_ITEMS = 30
+
+export function parseReadShelf(xml: string): Book[] {
+  const items = xml.match(ITEM_REGEX) || []
+  const books: Book[] = []
+
+  for (const item of items.slice(0, MAX_READ_ITEMS)) {
+    const title = extractTag(item, 'title')
+    const author = extractTag(item, 'author_name')
+    if (!title || !author) continue
+
+    const rating = parseInt(extractTag(item, 'user_rating'), 10)
+    books.push({
+      title: cleanTitle(title),
+      author: author.trim(),
+      dateRead: extractTag(item, 'user_read_at'),
+      link: extractTag(item, 'link'),
+      rating: Number.isNaN(rating) ? 0 : rating,
+    })
+  }
+
+  // Newest first; books without a read date sink to the bottom. The
+  // comparator must stay consistent (no early `return 0` for missing
+  // dates) or undated books float unpredictably to the top.
+  books.sort((a, b) => {
+    const aTime = a.dateRead ? new Date(a.dateRead).getTime() : 0
+    const bTime = b.dateRead ? new Date(b.dateRead).getTime() : 0
+    return bTime - aTime
+  })
+
+  return books
+}
+
+export function parseCurrentlyReadingShelf(
+  xml: string
+): CurrentlyReadingBook | null {
+  const [firstItem] = xml.match(ITEM_REGEX) || []
+  if (!firstItem) return null
+
+  const title = extractTag(firstItem, 'title')
+  const author = extractTag(firstItem, 'author_name')
+  if (!title || !author) return null
+
+  return {
+    title: cleanTitle(title),
+    author: author.trim(),
+    dateStarted: extractTag(firstItem, 'user_date_added'),
+    link: extractTag(firstItem, 'link'),
+  }
+}

--- a/src/lib/goodreads.ts
+++ b/src/lib/goodreads.ts
@@ -48,35 +48,35 @@ const cleanTitle = (title: string): string => {
 const ITEM_REGEX = /<item>[\s\S]*?<\/item>/g
 const MAX_READ_ITEMS = 30
 
-export function parseReadShelf(xml: string): Book[] {
-  const items = xml.match(ITEM_REGEX) || []
+export function parseReadShelf(...xmlPages: string[]): Book[] {
+  const items = xmlPages.flatMap((xml) => xml.match(ITEM_REGEX) || [])
   const books: Book[] = []
 
-  for (const item of items.slice(0, MAX_READ_ITEMS)) {
+  for (const item of items) {
     const title = extractTag(item, 'title')
     const author = extractTag(item, 'author_name')
-    if (!title || !author) continue
+    // A missing read date means the entry is shelf noise (bulk imports
+    // land without dates or ratings), not a finished book — skip it.
+    const dateRead = extractTag(item, 'user_read_at')
+    if (!title || !author || !dateRead) continue
 
     const rating = parseInt(extractTag(item, 'user_rating'), 10)
     books.push({
       title: cleanTitle(title),
       author: author.trim(),
-      dateRead: extractTag(item, 'user_read_at'),
+      dateRead,
       link: extractTag(item, 'link'),
       rating: Number.isNaN(rating) ? 0 : rating,
     })
   }
 
-  // Newest first; books without a read date sink to the bottom. The
-  // comparator must stay consistent (no early `return 0` for missing
-  // dates) or undated books float unpredictably to the top.
-  books.sort((a, b) => {
-    const aTime = a.dateRead ? new Date(a.dateRead).getTime() : 0
-    const bTime = b.dateRead ? new Date(b.dateRead).getTime() : 0
-    return bTime - aTime
-  })
+  books.sort(
+    (a, b) => new Date(b.dateRead).getTime() - new Date(a.dateRead).getTime()
+  )
 
-  return books
+  // Cap after filtering and sorting so shelf noise doesn't eat into the
+  // display budget.
+  return books.slice(0, MAX_READ_ITEMS)
 }
 
 export function parseCurrentlyReadingShelf(


### PR DESCRIPTION
Goodreads' shelf RSS mixes two encodings in the same feed — titles needing XML escaping arrive as `<title><![CDATA[...]]></title>`, plain ones as `<title>Flowers for Algernon</title>`. Our parser only matched the CDATA form, so it silently dropped 39 of 100 feed items, including the most recent dated, rated reads. Full diagnosis in `docs/bugs/2026-07-11-goodreads-cdata-only-parser-drops-books.md`.

Two compounding issues surfaced while verifying: a 2026-03-02 bulk import put ~96 undated, unrated entries on the read shelf that aren't actually finished books, and that import fills nearly all of RSS page 1 (Goodreads caps each page at 100 items, sorted by date added), pushing the real reading history onto page 2.

## Fix

- Extract parsing from the route into `src/lib/goodreads.ts` with an `extractTag` helper that accepts both CDATA and plain-text tag content (decoding XML entities for the plain form). Extraction makes the parser unit-testable without mocking `fetch`.
- Exclude shelf entries without a `user_read_at` — the parser can't otherwise distinguish bulk-import noise from finished books. Tradeoff: a finished book with no read date set on Goodreads won't appear.
- Fetch read-shelf RSS pages 1 and 2, merge, sort by read date (newest first), cap at 30 after filtering so import noise doesn't eat the display budget.
- Response shape is unchanged; the route just fetches and delegates.

## Testing

- 9 new unit tests in `src/lib/goodreads.test.ts`: both encodings, mixed feeds, entity decoding, undated-entry exclusion, multi-page merge, sort order. Full suite green (81/81), typecheck and prettier clean.
- Live check against the real feed: `/api/goodreads` returns 30 dated, rated books from Flowers for Algernon (5 stars, 06/13/2026) back to World War Z (12/2024), zero undated entries. Browser QA on `/` and `/read` with zero console errors.

Note for preview: the route has `revalidate = 3600`, so production can serve stale data for up to an hour after merge.

https://claude.ai/code/session_016buGuB1H2pwovZ4AY4VTMp